### PR TITLE
YANG updates to reflect information model / XML updates to match plurality

### DIFF
--- a/src/main/xml/draft-ietf-dmm-fpc-cpdp-04.xml
+++ b/src/main/xml/draft-ietf-dmm-fpc-cpdp-04.xml
@@ -476,7 +476,7 @@ DPN         |                 DPN        |
             |
             +---Mobility-profile
             |
-            +---DPN-group-peer
+            +---DPN-group-peers
 
               ]]></artwork>
             <postamble></postamble>
@@ -508,7 +508,7 @@ DPN         |                 DPN        |
                parameters of contexts can be automatically derived from
                this profile by FPC Agent. </t>
 
-               <t hangText="DPN-group-peer:"> Defines remote peers of
+               <t hangText="DPN-group-peers:"> Defines remote peers of
                DPN-group with parameters described in <xref
                target="dpn-peers"/>. </t>
 
@@ -517,7 +517,7 @@ DPN         |                 DPN        |
 
         <section anchor="dpn-peers" title="DPN-group Peers">
 
-        <t> DPN-group-peer defines parameters of remote peer DPNs as illustrated in
+        <t> DPN-group-peers defines parameters of remote peer DPNs as illustrated in
         <xref target="fig_dpn-peers-im"/>. </t>
 
         <t>
@@ -527,9 +527,9 @@ DPN         |                 DPN        |
 
 (DPN-groups)
     |
-    +---DPN-group-peer
+    +---DPN-group-peers
           |
-          +---Remote-DPN-group
+          +---Remote-DPN-group-id
           |
           +---Remote-mobility-profile
           |
@@ -548,7 +548,7 @@ DPN         |                 DPN        |
 
            <t><list hangIndent="24" style="hanging">
 
-               <t hangText="Remote-DPN-group:">Indicates peering DPN-Group.
+               <t hangText="Remote-DPN-group-id:">Indicates peering DPN-Group.
                </t>
 
                <t hangText="Remote-mobility-profile:">Defines
@@ -710,7 +710,7 @@ DPN         |                 DPN        |
 
  (FPC-Policy)
      |
-     +---Action
+     +---Actions
             |
             +---Action-id
             |
@@ -767,19 +767,19 @@ DPN         |                 DPN        |
      |
      +---Policies
             |
-            +---Policy--id
+            +---Policy-id
             |
-            +---Rule
+            +---Rules
                   |
                   +---Order
                   |
-                  +---Descriptor
+                  +---Descriptors
                   |      |
                   |      +---Descriptor-id
                   |      |
                   |      +---Direction
                   |
-                  +---Action
+                  +---Actions
                          |
                          +---Action-id
                          |
@@ -810,14 +810,14 @@ DPN         |                 DPN        |
                <t hangText="Order:">Specifies ordering if the Rule has
                multiple Descriptors and Action sets.</t>
 
-               <t hangText="Descriptor:">List of Descriptors.</t>
+               <t hangText="Descriptors:">List of Descriptors.</t>
 
                <t hangText="Descriptor-id:">Indicates each Descriptor in the Rule.</t>
 
                <t hangText="Direction:">Specifies which
                direction applies, such as upstream, downstream or both.</t>
 
-               <t hangText="Action:">List of Actions.</t>
+               <t hangText="Actions:">List of Actions.</t>
 
                <t hangText="Action-id:">Indicates each Action in the rule.</t>
 
@@ -847,7 +847,7 @@ DPN         |                 DPN        |
             |
             +---Policy-group-id
             |
-            +---Policy
+            +---Policies
 
               ]]></artwork>
             <postamble></postamble>
@@ -861,7 +861,7 @@ DPN         |                 DPN        |
                they like. e.g: URI, UUID, certain length of string and
                unsigned-integer, etc. </t>
 
-               <t hangText="Policy:">List of Policies in the Policy-group.
+               <t hangText="Policies:">List of Policies in the Policy-group.
                </t>
 
            </list></t>
@@ -900,11 +900,11 @@ DPN         |                 DPN        |
 
 (FPC-Mobility)
         |
-        +---Port
+        +---Ports
                |
                +---Port-id
                |
-               +---Policy-group-reference
+               +---Policy-groups
 
               ]]></artwork>
             <postamble></postamble>
@@ -917,7 +917,7 @@ DPN         |                 DPN        |
             be chose by operator as they like. e.g: URI, UUID, certain
             length of string and unsigned-integer, etc. </t>
 
-            <t hangText="Policy-group-reference:">List of references to
+            <t hangText="Policy-groups:">List of references to
             Policy-groups which apply to the Port. </t>
 
         </list></t>
@@ -948,15 +948,15 @@ DPN         |                 DPN        |
 
 (FPC-Mobility)
         |
-        +---Context
+        +---Contexts
                |
                +---Context-id
                |
-               +---Port-reference
+               +---Ports
                |
-               +---DPN-group-reference
+               +---DPN-group
                |
-               +---Delegating-ip-prefix
+               +---Delegating-ip-prefixes
 
               ]]></artwork>
             <postamble></postamble>
@@ -970,17 +970,17 @@ DPN         |                 DPN        |
             UUID, certain length of string and unsigned-integer, etc.,
             </t>
 
-            <t hangText="Port-reference:">List of Ports. When a Context
+            <t hangText="Ports:">List of Ports. When a Context
             is applied to Port(s), the context is configured by policies
             of those Port(s). Port-id references indicate Ports which apply
             to the Context. Context can be a part of multiple Ports
             which have different policies. </t>
 
-            <t hangText="DPN-group-reference:">The DPN-group assigned to
+            <t hangText="DPN-group:">The DPN-group assigned to
             the Context.
             </t>
 
-            <t hangText="Delegating-ip-prefix:">List of IP prefixes to
+            <t hangText="Delegating-ip-prefixes:">List of IP prefixes to
             be delegated to the mobile node of the context. </t>
 
         </list></t>
@@ -1004,7 +1004,7 @@ DPN         |                 DPN        |
     |
     +---UL-Tunnel-remote-address
     |
-    +---UL-Mtu-size
+    +---UL-Tunnel-mtu-size
     |
     +---UL-Mobility-specific-tunnel-parameters
     |
@@ -1029,7 +1029,7 @@ DPN         |                 DPN        |
             <t hangText="UL-Tunnel-remote-address:">Specifies uplink
             endpoint address of the remote DPN. </t>
 
-            <t hangText="UL-Mtu-size:">Specifies uplink MTU size of
+            <t hangText="UL-Tunnel-Mtu-size:">Specifies uplink MTU size of
             tunnel. </t>
 
             <t hangText="UL-Mobility-specific-tunnel-parameters:">
@@ -1068,7 +1068,7 @@ DPN         |                 DPN        |
     |
     +---DL-Tunnel-remote-address
     |
-    +---DL-Mtu-size
+    +---DL-Tunnel-Mtu-size
     |
     +---DL-Mobility-specific-tunnel-parameters
     |
@@ -1095,7 +1095,7 @@ DPN         |                 DPN        |
             endpoint address of the remote DPN.
             </t>
 
-            <t hangText="DL-Mtu-size:">Specifies downlink MTU size of
+            <t hangText="DL-Tunnel-Mtu-size:">Specifies downlink MTU size of
             tunnel.</t>
 
             <t hangText="DL-Mobility-specific-tunnel-parameters:">
@@ -1151,7 +1151,7 @@ DPN         |                 DPN        |
          |
          +---Tunnel-remote-address
          |
-         +---Mtu-size
+         +---Tunnel-mtu-size
          |
          +---Mobility-specific-tunnel-parameters
          |
@@ -1182,7 +1182,7 @@ DPN         |                 DPN        |
             <t hangText="Tunnel-remote-address:">Specifies endpoint
             address of remote DPN at the uplink or downlink.</t>
 
-            <t hangText="Mtu-size:">Specifies the MTU size of
+            <t hangText="Tunnel-mtu-size:">Specifies the MTU size of
             tunnel on uplink or downlink. </t>
 
             <t hangText="Mobility-specific-tunnel-parameters:">

--- a/src/main/yang/ietf-dmm-fpc-pmip.yang
+++ b/src/main/yang/ietf-dmm-fpc-pmip.yang
@@ -89,66 +89,58 @@ module ietf-dmm-fpc-pmip {
       }
     }
 
-    // Topology
-    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-topology/fpcagent:dpn-groups/fpcagent:dpn-group-peers/fpcagent:profile-parameters" {
+    // Contexts Update - Contexts / UL / mob-profile, Contexts / DL / mob-profile and Contexts / dpns / mobility-tunnel-parameters
+    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:ul/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
+      case pmip-tunnel {
+        uses fpc-pmip:pmip-mobility;
+        uses traffic-selectors:traffic-selector;
+      }
+    }
+    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:ul/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
+      case pmip-tunnel {
+        uses fpc-pmip:pmip-mobility;
+        uses traffic-selectors:traffic-selector;
+      }
+    }
+    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:ul/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case pmip-tunnel {
         uses fpc-pmip:pmip-mobility;
         uses traffic-selectors:traffic-selector;
       }
     }
 
-    // Contexts Update - Contexts / UL / mob-profile, Contexts / DL / mob-profile and Contexts / dpns / mobility-profile
-    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:ul/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:dl/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case pmip-tunnel {
         uses fpc-pmip:pmip-mobility;
         uses traffic-selectors:traffic-selector;
       }
     }
-    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:ul/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dl/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case pmip-tunnel {
         uses fpc-pmip:pmip-mobility;
         uses traffic-selectors:traffic-selector;
       }
     }
-    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:ul/fpcagent:mobility-profile/fpcagent:profile-parameters" {
-      case pmip-tunnel {
-        uses fpc-pmip:pmip-mobility;
-        uses traffic-selectors:traffic-selector;
-      }
-    }
-
-    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:dl/fpcagent:mobility-profile/fpcagent:profile-parameters" {
-      case pmip-tunnel {
-        uses fpc-pmip:pmip-mobility;
-        uses traffic-selectors:traffic-selector;
-      }
-    }
-    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dl/fpcagent:mobility-profile/fpcagent:profile-parameters" {
-      case pmip-tunnel {
-        uses fpc-pmip:pmip-mobility;
-        uses traffic-selectors:traffic-selector;
-      }
-    }
-    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dl/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dl/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case pmip-tunnel {
         uses fpc-pmip:pmip-mobility;
         uses traffic-selectors:traffic-selector;
       }
     }
 
-    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:dpns/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:dpns/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case pmip-tunnel {
         uses fpc-pmip:pmip-mobility;
         uses traffic-selectors:traffic-selector;
       }
     }
-    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dpns/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dpns/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case pmip-tunnel {
         uses fpc-pmip:pmip-mobility;
         uses traffic-selectors:traffic-selector;
       }
     }
-    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dpns/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dpns/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case pmip-tunnel {
         uses fpc-pmip:pmip-mobility;
         uses traffic-selectors:traffic-selector;
@@ -156,33 +148,33 @@ module ietf-dmm-fpc-pmip {
     }
 
     // QoS Updates - Context / UL / qosprofile, Context / DL / QoS Profile
-    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:ul/fpcagent:qos-profile/fpcagent:value" {
+    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:ul/fpcagent:qos-profile-parameters/fpcagent:value" {
       case qos-pmip {
           uses qos-pmip:qosattribute;
       }
     }
-    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:ul/fpcagent:qos-profile/fpcagent:value" {
+    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:ul/fpcagent:qos-profile-parameters/fpcagent:value" {
       case qos-pmip {
           uses qos-pmip:qosattribute;
       }
     }
-    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:ul/fpcagent:qos-profile/fpcagent:value" {
+    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:ul/fpcagent:qos-profile-parameters/fpcagent:value" {
       case qos-pmip {
           uses qos-pmip:qosattribute;
       }
     }
 
-    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:dl/fpcagent:qos-profile/fpcagent:value" {
+    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:dl/fpcagent:qos-profile-parameters/fpcagent:value" {
       case qos-pmip {
           uses qos-pmip:qosattribute;
       }
     }
-    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dl/fpcagent:qos-profile/fpcagent:value" {
+    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dl/fpcagent:qos-profile-parameters/fpcagent:value" {
       case qos-pmip {
           uses qos-pmip:qosattribute;
       }
     }
-    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dl/fpcagent:qos-profile/fpcagent:value" {
+    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dl/fpcagent:qos-profile-parameters/fpcagent:value" {
       case qos-pmip {
           uses qos-pmip:qosattribute;
       }

--- a/src/main/yang/ietf-dmm-fpcagent.yang
+++ b/src/main/yang/ietf-dmm-fpcagent.yang
@@ -16,15 +16,6 @@ module ietf-dmm-fpcagent {
         description "Changes based on -04 version of FPC draft.";
         reference "draft-ietf-dmm-fpc-cpdp-04";
     }
-
-    feature fpc-basic-agent {
-        description "This is an agent co-located with a DPN.  In this case
-        only DPN Peer Groups, the DPN Id and Control Protocols are exposed
-        along with the core structures.";
-    }
-    feature fpc-multi-dpn {
-        description "The agent supports multiple DPNs.";
-    }
     feature fpc-cloning {
       description "An ability to support cloning in the RPC.";
     }
@@ -57,8 +48,23 @@ module ietf-dmm-fpcagent {
         type fpcbase:fpc-identity;
     }
 
-    // Top Level Structures
+    grouping basename-info {
+          leaf basename {
+            if-feature fpcagent:fpc-basename-registry;
+            description "Rules Basename";
+            type fpcbase:fpc-identity;
+          }
+          leaf base-state {
+            if-feature fpcagent:fpc-basename-registry;
+            type string;
+          }
+          leaf base-checkpoint {
+            if-feature fpcagent:fpc-basename-registry;
+            type string;
+          }
+    }
 
+    // Top Level Structures
     container tenants {
         description "";
 
@@ -66,8 +72,7 @@ module ietf-dmm-fpcagent {
             description "";
             key "tenant-id";
             leaf tenant-id {
-                type uint32;
-                description "";
+                type fpcbase:fpc-identity;
             }
 
             container fpc-policy {
@@ -103,29 +108,40 @@ module ietf-dmm-fpcagent {
             }
             container fpc-topology {
               // Basic Agent Topology Structures
+              list domains {
+                key domain-id;
+                uses fpcbase:fpc-domain;
+                uses fpcagent:basename-info;
+              }
+
               list dpn-group-peers {
-                  if-feature fpc-basic-agent;
+                  if-feature fpcbase:fpc-basic-agent;
                   key "remote-dpn-group-id";
                   uses fpcbase:fpc-dpn-peer-group;
               }
               leaf dpn-id {
-                if-feature fpc-basic-agent;
+                if-feature fpcbase:fpc-basic-agent;
                 type fpcbase:fpc-dpn-id;
               }
               leaf-list control-protocols {
-                if-feature fpc-basic-agent;
+                if-feature fpcbase:fpc-basic-agent;
                 type identityref {
                   base "fpcbase:fpc-dpn-control-protocol";
                 }
               }
 
               list dpn-groups {
-                  if-feature fpc-multi-dpn;
-                  key group-id;
+                  if-feature fpcbase:fpc-multi-dpn;
+                  key dpn-group-id;
                   uses fpcagent:fpc-dpn-group;
+                  list domains {
+                    key domain-id;
+                    uses fpcbase:fpc-domain;
+                    uses fpcagent:basename-info;
+                  }
               }
               list dpns {
-                  if-feature fpc-multi-dpn;
+                  if-feature fpcbase:fpc-multi-dpn;
                   key dpn-id;
                   uses fpcbase:fpc-dpn;
               }
@@ -164,33 +180,15 @@ module ietf-dmm-fpcagent {
           type fpcagent:error-type-id;
         }
       }
-
-      // Base Name Registry Feature
-      list basename-registry {
-          description "A registy for multiple clients operating upon the same base,
-            e.g. '/mcc:01/mnc:01' to determine if a Client has already provisioned
-            common Policy on the Agent / DPN";
-          if-feature fpcagent:fpc-basename-registry;
-          key basename;
-          leaf basename {
-              type fpcbase:fpc-identity;
-          }
-          leaf state {
-              type string;
-          }
-          leaf checkpoint {
-              type string;
-          }
-      }
     }
 
 
     // Multi-DPN Agent Structures
     grouping fpc-dpn-group {
-        leaf group-id {
+        leaf dpn-group-id {
             type fpcbase:fpc-dpn-group-id;
         }
-        leaf fowarding-role {
+        leaf data-plane-role {
             type identityref {
                 base "fpcbase:fpc-forwaridingplane-role";
             }

--- a/src/main/yang/ietf-dmm-fpcbase.yang
+++ b/src/main/yang/ietf-dmm-fpcbase.yang
@@ -16,6 +16,15 @@ module ietf-dmm-fpcbase {
         reference "draft-ietf-dmm-fpc-cpdp-04";
     }
 
+    feature fpc-basic-agent {
+        description "This is an agent co-located with a DPN.  In this case
+        only DPN Peer Groups, the DPN Id and Control Protocols are exposed
+        along with the core structures.";
+    }
+    feature fpc-multi-dpn {
+        description "The agent supports multiple DPNs.";
+    }
+
     typedef fpc-identity {
         type union {
             type uint32;
@@ -43,18 +52,22 @@ module ietf-dmm-fpcbase {
     }
 
     // Descriptor Structure
-    typedef fpc-descriptor-id {
+    typedef fpc-descriptor-id-type {
         type fpcbase:fpc-identity;
         description "Descriptor-ID";
     }
     identity fpc-descriptor-type {
         description "A traffic descriptor";
     }
+    grouping fpc-descriptor-id {
+      leaf descriptor-id {
+        type fpcbase:fpc-identity;
+      }
+    }
     grouping fpc-descriptor {
-        leaf descriptor-id {
-              type fpcbase:fpc-descriptor-id;
-        }
+        uses fpcbase:fpc-descriptor-id;
         leaf descriptor-type {
+          mandatory true;
           type identityref {
             base "fpc-descriptor-type";
           }
@@ -70,18 +83,22 @@ module ietf-dmm-fpcbase {
     }
 
     // Action Structure
-    typedef fpc-action-id {
+    typedef fpc-action-id-type {
         type fpcbase:fpc-identity;
         description "Action-ID";
     }
     identity fpc-action-type {
         description "Action Type";
     }
+    grouping fpc-action-id {
+      leaf action-id {
+        type fpcbase:fpc-action-id-type;
+      }
+    }
     grouping fpc-action {
-        leaf action-id {
-            type fpcbase:fpc-action-id;
-        }
+        uses fpcbase:fpc-action-id;
         leaf action-type {
+          mandatory true;
           type identityref {
             base "fpc-action-type";
           }
@@ -99,17 +116,21 @@ module ietf-dmm-fpcbase {
     // Rule Structure
     grouping fpc-rule {
         description
-          "FPC Rule";
-        list action {
+          "FPC Rule.  When no actions are present the action is DROP.
+          When no Descriptors are empty the default is 'all traffic'.";
+        list descriptors {
+          key descriptor-id;
+          uses fpcbase:fpc-descriptor-id;
+          leaf direction {
+            type fpc-direction;
+          }
+        }
+        list actions {
           key action-id;
           leaf order {
               type uint32;
           }
-          uses fpcbase:fpc-action;
-        }
-        list descriptor {
-          key descriptor-id;
-          uses fpcbase:fpc-descriptor;
+          uses fpcbase:fpc-action-id;
         }
     }
 
@@ -121,7 +142,7 @@ module ietf-dmm-fpcbase {
         leaf policy-id {
             type fpcbase:fpc-policy-id;
         }
-        list rule {
+        list rules {
             key order;
             leaf order {
               type uint32;
@@ -135,12 +156,12 @@ module ietf-dmm-fpcbase {
         type fpcbase:fpc-identity;
     }
     grouping fpc-policy-group {
-        leaf policy-group-id {
-            type fpcbase:fpc-policy-group-id;
-        }
-        leaf-list policy {
-            type fpcbase:fpc-policy-id;
-        }
+      leaf policy-group-id {
+        type fpcbase:fpc-policy-group-id;
+      }
+      leaf-list policies {
+        type fpcbase:fpc-policy-id;
+      }
     }
 
     // Mobility Structures
@@ -152,9 +173,8 @@ module ietf-dmm-fpcbase {
         leaf port-id {
             type fpcbase:fpc-port-id;
         }
-        list policy-groups {
-            key policy-group-id;
-            uses fpcbase:fpc-policy-group;
+        leaf-list policy-groups {
+            type fpcbase:fpc-policy-group-id;
         }
     }
 
@@ -164,31 +184,31 @@ module ietf-dmm-fpcbase {
     }
     grouping fpc-context-profile {
         description "A profile that applies to a specific direction";
-        leaf remote-address {
+        leaf tunnel-local-address {
             type inet:ip-address;
             description "Uplink endpoint address of the DPN which agent exists.";
         }
-        leaf local-address {
+        leaf tunnel-remote-address {
             type inet:ip-address;
             description "Uplink endpoint address of the DPN which agent exists.";
         }
-        leaf mtu {
+        leaf tunnel-mtu-size {
             type uint32;
             description "Tunnel MTU size";
         }
-        container mobility-profile {
+        container mobility-tunnel-parameters {
             description "Specifies profile specific uplink tunnel parameters to the DPN which the agent exists. The profiles includes GTP/TEID for 3gpp profile, GRE/Key for ietf-pmip profile, or new profile if anyone will define it.";
             uses fpcbase:mobility-info;
         }
         container nexthop {
             uses fpcbase:fpc-nexthop;
         }
-        container qos-profile {
+        container qos-profile-parameters {
             uses fpcbase:fpc-qos-profile;
         }
         container dpn-parameters {
         }
-        list vendor-params {
+        list vendor-parameters {
             key "vendor-id vendor-type";
             uses fpcbase:vendor-attributes;
         }
@@ -200,18 +220,7 @@ module ietf-dmm-fpcbase {
          enum downlink;
        }
     }
-    grouping assignable-dpns {
-        list dpns {
-            key dpn-id;
-            leaf dpn-id {
-                type fpcbase:fpc-dpn-id;
-            }
-            leaf direction {
-                type fpcbase:fpc-direction;
-            }
-            uses fpcbase:fpc-context-profile;
-        }
-    }
+
     grouping fpc-context {
         leaf context-id {
             type fpcbase:fpc-context-id;
@@ -219,19 +228,35 @@ module ietf-dmm-fpcbase {
         leaf-list ports {
             type fpcbase:fpc-port-id;
         }
+        leaf dpn-group {
+          type fpcbase:fpc-dpn-group-id;
+        }
         leaf-list delegating-ip-prefixes {
             type inet:ip-prefix;
         }
         container ul {
+            if-feature fpcbase:fpc-basic-agent;
             uses fpcbase:fpc-context-profile;
         }
         container dl {
+            if-feature fpcbase:fpc-basic-agent;
+            uses fpcbase:fpc-context-profile;
+        }
+        list dpns {
+            if-feature fpcbase:fpc-multi-dpn;
+            key "dpn-id direction";
+            leaf dpn-id {
+                type fpcbase:fpc-dpn-id;
+            }
+            leaf direction {
+                mandatory true;
+                type fpcbase:fpc-direction;
+            }
             uses fpcbase:fpc-context-profile;
         }
         leaf parent-context {
             type fpcbase:fpc-context-id;
         }
-        uses fpcbase:assignable-dpns;
     }
 
     // Mobility (Tunnel) Information
@@ -320,6 +345,22 @@ module ietf-dmm-fpcbase {
     }
 
     // Topology
+    typedef fpc-domain-id {
+        type fpcbase:fpc-identity;
+    }
+    grouping fpc-domain {
+      leaf domain-id {
+        type fpcbase:fpc-domain-id;
+      }
+      leaf domain-name {
+        type string;
+      }
+      leaf domain-type {
+        type string;
+      }
+    }
+
+
     typedef fpc-dpn-id {
         type fpcbase:fpc-identity;
         description "DPN Identifier";
@@ -329,18 +370,16 @@ module ietf-dmm-fpcbase {
     }
     grouping fpc-dpn {
         leaf dpn-id {
-            type fpcbase:fpc-dpn-id;
+          type fpcbase:fpc-dpn-id;
         }
-        leaf address {
-            type inet:ip-address;
-        }
-        leaf-list control-protocols {
-            type identityref {
-                base "fpcbase:fpc-dpn-control-protocol";
-            }
+        leaf dpn-name {
+          type string;
         }
         leaf-list dpn-groups {
-            type fpcbase:fpc-dpn-group-id;
+          type fpcbase:fpc-dpn-group-id;
+        }
+        leaf node-reference {
+          type instance-identifier;
         }
     }
 
@@ -362,20 +401,24 @@ module ietf-dmm-fpcbase {
         leaf remote-dpn-group-id {
             type fpcbase:fpc-dpn-group-id;
         }
+        leaf remote-mobility-profile {
+            type identityref {
+                base "fpcbase:fpc-mobility-profile-type";
+            }
+        }
+        leaf remote-data-plane-role {
+            type identityref {
+                base "fpcbase:fpc-forwaridingplane-role";
+            }
+        }
         leaf remote-endpoint-address {
             type inet:ip-address;
         }
         leaf local-endpoint-address {
             type inet:ip-address;
         }
-        leaf mtu-size {
+        leaf tunnel-mtu-size {
             type uint32;
-        }
-        uses fpcbase:mobility-info;
-        leaf fowarding-role {
-            type identityref {
-                base "fpcbase:fpc-forwaridingplane-role";
-            }
         }
     }
 

--- a/src/main/yang/ietf-dmm-threegpp.yang
+++ b/src/main/yang/ietf-dmm-threegpp.yang
@@ -27,7 +27,7 @@ module ietf-dmm-threegpp {
 
     // Profile Type
     identity threeGPP-mobility {
-        base "fpcbase:fpc-mobility-profile-type";
+         base "fpcbase:fpc-mobility-profile-type";
     }
 
     // Tunnel Types
@@ -60,7 +60,7 @@ module ietf-dmm-threegpp {
     }
 
     // QoS Profile
-    identity threeGPP-QoS-Profile {
+    identity threeGPP-qos-profile-parameters {
         base "fpcbase:fpc-qos-type";
     }
 
@@ -273,40 +273,32 @@ module ietf-dmm-threegpp {
       }
     }
 
-    // Topology
-    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-topology/fpcagent:dpn-groups/fpcagent:dpn-group-peers/fpcagent:profile-parameters" {
-      case threegpp-tunnel {
-          uses threegpp:threeGPP-tunnel;
-          uses threegpp:tft;
-      }
-    }
-
     // Contexts Update - Contexts / UL / mob-profile
-    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:ul/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:ul/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case threegpp-tunnel {
           uses threegpp:threeGPP-tunnel;
           uses threegpp:tft;
       }
     }
-    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:ul/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:ul/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case threegpp-tunnel {
           uses threegpp:threeGPP-tunnel;
           uses threegpp:tft;
       }
     }
-    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:ul/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:ul/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case threegpp-tunnel {
           uses threegpp:threeGPP-tunnel;
           uses threegpp:tft;
       }
     }
-    augment "/fpcagent:configure/fpcagent:output/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:ul/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:configure/fpcagent:output/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:ul/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case threegpp-tunnel {
           uses threegpp:threeGPP-tunnel;
           uses threegpp:tft;
       }
     }
-    augment "/fpcagent:configure-bundles/fpcagent:output/fpcagent:bundles/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:ul/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:configure-bundles/fpcagent:output/fpcagent:bundles/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:ul/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case threegpp-tunnel {
           uses threegpp:threeGPP-tunnel;
           uses threegpp:tft;
@@ -314,31 +306,31 @@ module ietf-dmm-threegpp {
     }
 
     // Contexts Update - Contexts / DL / mob-profile
-    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:dl/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:dl/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case threegpp-tunnel {
           uses threegpp:threeGPP-tunnel;
           uses threegpp:tft;
       }
     }
-    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dl/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dl/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case threegpp-tunnel {
           uses threegpp:threeGPP-tunnel;
           uses threegpp:tft;
       }
     }
-    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dl/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dl/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case threegpp-tunnel {
           uses threegpp:threeGPP-tunnel;
           uses threegpp:tft;
       }
     }
-    augment "/fpcagent:configure/fpcagent:output/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:dl/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:configure/fpcagent:output/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:dl/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case threegpp-tunnel {
           uses threegpp:threeGPP-tunnel;
           uses threegpp:tft;
       }
     }
-    augment "/fpcagent:configure-bundles/fpcagent:output/fpcagent:bundles/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:dl/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:configure-bundles/fpcagent:output/fpcagent:bundles/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:dl/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case threegpp-tunnel {
           uses threegpp:threeGPP-tunnel;
           uses threegpp:tft;
@@ -346,32 +338,32 @@ module ietf-dmm-threegpp {
     }
 
 
-    // Contexts Update -  Contexts / dpns / mobility-profile
-    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:dpns/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    // Contexts Update -  Contexts / dpns / mobility-tunnel-parameters
+    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:dpns/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case threegpp-tunnel {
           uses threegpp:threeGPP-tunnel;
           uses threegpp:tft;
       }
     }
-    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dpns/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dpns/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case threegpp-tunnel {
           uses threegpp:threeGPP-tunnel;
           uses threegpp:tft;
       }
     }
-    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dpns/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dpns/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case threegpp-tunnel {
           uses threegpp:threeGPP-tunnel;
           uses threegpp:tft;
       }
     }
-    augment "/fpcagent:configure/fpcagent:output/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:dpns/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:configure/fpcagent:output/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:dpns/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case threegpp-tunnel {
           uses threegpp:threeGPP-tunnel;
           uses threegpp:tft;
       }
     }
-    augment "/fpcagent:configure-bundles/fpcagent:output/fpcagent:bundles/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:dpns/fpcagent:mobility-profile/fpcagent:profile-parameters" {
+    augment "/fpcagent:configure-bundles/fpcagent:output/fpcagent:bundles/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:dpns/fpcagent:mobility-tunnel-parameters/fpcagent:profile-parameters" {
       case threegpp-tunnel {
           uses threegpp:threeGPP-tunnel;
           uses threegpp:tft;
@@ -380,54 +372,54 @@ module ietf-dmm-threegpp {
 
 
     // QoS Updates - Context / UL / qosprofile
-    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:ul/fpcagent:qos-profile/fpcagent:value" {
+    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:ul/fpcagent:qos-profile-parameters/fpcagent:value" {
       case threegpp-qos {
           uses threegpp:threeGPP-QoS;
       }
     }
-    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:ul/fpcagent:qos-profile/fpcagent:value" {
+    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:ul/fpcagent:qos-profile-parameters/fpcagent:value" {
       case threegpp-qos {
           uses threegpp:threeGPP-QoS;
       }
     }
-    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:ul/fpcagent:qos-profile/fpcagent:value" {
+    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:ul/fpcagent:qos-profile-parameters/fpcagent:value" {
       case threegpp-qos {
           uses threegpp:threeGPP-QoS;
       }
     }
-    augment "/fpcagent:configure/fpcagent:output/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:ul/fpcagent:qos-profile/fpcagent:value" {
+    augment "/fpcagent:configure/fpcagent:output/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:ul/fpcagent:qos-profile-parameters/fpcagent:value" {
       case threegpp-qos {
           uses threegpp:threeGPP-QoS;
       }
     }
-    augment "/fpcagent:configure-bundles/fpcagent:output/fpcagent:bundles/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:ul/fpcagent:qos-profile/fpcagent:value" {
+    augment "/fpcagent:configure-bundles/fpcagent:output/fpcagent:bundles/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:ul/fpcagent:qos-profile-parameters/fpcagent:value" {
       case threegpp-qos {
           uses threegpp:threeGPP-QoS;
       }
     }
 
     // QoS Updates -  Context / DL / QoS Profile
-    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:dl/fpcagent:qos-profile/fpcagent:value" {
+    augment "/fpcagent:tenants/fpcagent:tenant/fpcagent:fpc-mobility/fpcagent:contexts/fpcagent:dl/fpcagent:qos-profile-parameters/fpcagent:value" {
       case threegpp-qos {
           uses threegpp:threeGPP-QoS;
       }
     }
-    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dl/fpcagent:qos-profile/fpcagent:value" {
+    augment "/fpcagent:configure/fpcagent:input/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dl/fpcagent:qos-profile-parameters/fpcagent:value" {
       case threegpp-qos {
           uses threegpp:threeGPP-QoS;
       }
     }
-    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dl/fpcagent:qos-profile/fpcagent:value" {
+    augment "/fpcagent:configure-bundles/fpcagent:input/fpcagent:bundles/fpcagent:op_body/fpcagent:create_or_update/fpcagent:contexts/fpcagent:dl/fpcagent:qos-profile-parameters/fpcagent:value" {
       case threegpp-qos {
           uses threegpp:threeGPP-QoS;
       }
     }
-    augment "/fpcagent:configure/fpcagent:output/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:dl/fpcagent:qos-profile/fpcagent:value" {
+    augment "/fpcagent:configure/fpcagent:output/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:dl/fpcagent:qos-profile-parameters/fpcagent:value" {
       case threegpp-qos {
           uses threegpp:threeGPP-QoS;
       }
     }
-    augment "/fpcagent:configure-bundles/fpcagent:output/fpcagent:bundles/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:dl/fpcagent:qos-profile/fpcagent:value" {
+    augment "/fpcagent:configure-bundles/fpcagent:output/fpcagent:bundles/fpcagent:result-type/fpcagent:create-or-update-success/fpcagent:contexts/fpcagent:dl/fpcagent:qos-profile-parameters/fpcagent:value" {
       case threegpp-qos {
           uses threegpp:threeGPP-QoS;
       }


### PR DESCRIPTION
Note - there is an issue with  'Remote-DPN-group:  Indicates peering DPN-Group' as a definition which needs to be fixed.
